### PR TITLE
Deep-linkable apps (URL hash) + in-app docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ and camera and implements the lifecycle hooks it needs (`setup`, `update`,
 [`Playground`](src/core/Playground.ts) orchestrator owns the renderer and render
 loop, handles resizing and pointer routing, and switches between apps. Controls
 are declared per app by binding a `params` object to a Tweakpane folder in
-`setupControls`, and each app disposes its GPU resources on teardown.
+`setupControls`, and each app disposes its GPU resources on teardown. The active
+app is mirrored in the URL hash (e.g. `#ocean`) so any experiment can be linked
+to directly, and each app's control panel has a **Read the docs** button linking
+to its deep-dive in [`docs/apps/`](docs/apps/).
 
 ### Scaffolding new apps
 

--- a/src/core/Playground.ts
+++ b/src/core/Playground.ts
@@ -3,9 +3,23 @@ import { Pane } from "tweakpane";
 import type { FolderApi } from "tweakpane";
 import type { App, AppContext } from "./App";
 
+const REPO_URL = "https://github.com/DanKane2029/three-js-playground";
+
+/** URL-safe slug for an app name, e.g. "Planet Generator" -> "planet-generator". */
+const slugify = (name: string): string =>
+	name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+
+/** GitHub link to an app's educational write-up in docs/apps/<slug>/. */
+const docsUrl = (app: App): string =>
+	`${REPO_URL}/blob/main/docs/apps/${slugify(app.name)}/README.md`;
+
 /**
  * Owns the renderer, the render loop, the Tweakpane panel, resize handling and
- * pointer routing, and switches between the registered apps.
+ * pointer routing, and switches between the registered apps. The active app is
+ * mirrored in the URL hash (e.g. `#ocean`) so it can be linked to directly.
  */
 export class Playground {
 	private readonly renderer: WebGLRenderer;
@@ -13,6 +27,7 @@ export class Playground {
 	private readonly clock = new Clock();
 	private readonly apps: App[];
 	private readonly selector: { app: string };
+	private readonly appBinding: { refresh(): void };
 
 	private current!: App;
 	private appFolder: FolderApi | null = null;
@@ -33,8 +48,11 @@ export class Playground {
 		});
 		this.taglineEl = document.getElementById("app-tagline");
 
-		this.selector = { app: apps[0].name };
-		this.pane
+		// Honour a deep link like `#ocean`; otherwise start with the first app.
+		const initial = this.appForHash(window.location.hash) ?? apps[0];
+
+		this.selector = { app: initial.name };
+		this.appBinding = this.pane
 			.addBinding(this.selector, "app", {
 				label: "App",
 				options: Object.fromEntries(apps.map((a) => [a.name, a.name])),
@@ -45,13 +63,27 @@ export class Playground {
 			});
 
 		this.bindEvents(canvas);
-		this.loadApp(apps[0]);
+		this.loadApp(initial);
+
+		// Reflect the initial app in the URL without adding a history entry.
+		const slug = slugify(initial.name);
+		if (window.location.hash.replace(/^#/, "") !== slug)
+			window.history.replaceState(null, "", `#${slug}`);
+		window.addEventListener("hashchange", this.onHashChange);
+
 		this.resize();
 		this.renderer.setAnimationLoop(this.frame);
 	}
 
 	private get size(): { width: number; height: number } {
 		return { width: window.innerWidth, height: window.innerHeight };
+	}
+
+	/** Find the app whose slug matches a `#slug` hash, if any. */
+	private appForHash(hash: string): App | undefined {
+		const slug = hash.replace(/^#/, "");
+		if (!slug) return undefined;
+		return this.apps.find((a) => slugify(a.name) === slug);
 	}
 
 	private loadApp(app: App): void {
@@ -63,6 +95,14 @@ export class Playground {
 
 		this.appFolder?.dispose();
 		this.appFolder = this.pane.addFolder({ title: app.name });
+
+		// A link to this app's educational docs, above its controls.
+		this.appFolder
+			.addButton({ title: "📖 Read the docs" })
+			.on("click", () =>
+				window.open(docsUrl(app), "_blank", "noopener,noreferrer")
+			);
+
 		app.setupControls(this.appFolder);
 
 		if (this.taglineEl) this.taglineEl.textContent = app.description;
@@ -71,7 +111,20 @@ export class Playground {
 	private switchApp(next: App): void {
 		this.current.dispose();
 		this.loadApp(next);
+
+		// Keep the dropdown and the URL in sync with the active app.
+		this.selector.app = next.name;
+		this.appBinding.refresh();
+		const slug = slugify(next.name);
+		if (window.location.hash.replace(/^#/, "") !== slug)
+			window.location.hash = slug;
 	}
+
+	/** React to back/forward navigation or a manually edited `#slug`. */
+	private onHashChange = (): void => {
+		const next = this.appForHash(window.location.hash);
+		if (next && next !== this.current) this.switchApp(next);
+	};
 
 	private frame = (): void => {
 		const dt = this.clock.getDelta();


### PR DESCRIPTION
Adds the two platform features discussed.

## URL-hash deep-linking
The active app is now mirrored in the URL hash, so every experiment has a shareable link:
- Opening `…/#ocean` starts directly on that app (falls back to the first app for an unknown/empty hash).
- Picking an app from the dropdown updates the hash.
- Back/forward navigation (and manually editing the hash) switches apps via `hashchange`.

Implemented in `Playground` with a small `slugify(name)` ("Planet Generator" → `planet-generator`), matching the `docs/apps/<slug>/` folders. The initial reflect uses `replaceState` so it doesn't add a spurious history entry.

## In-app docs link
Each app's Tweakpane panel gets a **📖 Read the docs** button that opens that app's educational write-up in `docs/apps/<slug>/README.md` on GitHub — connecting the running demo to the writing.

## Verified (headless WebGL)
- `#ocean` deep-link → Ocean selected
- Docs button present
- Dropdown switch → hash updates (`#fluid`)
- Setting `#mandelbulb` → Mandelbulb selected
- 0 page errors; `tsc`/`eslint`/`vite build` all clean

No Claude co-author trailer on the commit.