### PR TITLE
Code-split apps (lazy loading) + Three.js vendor chunk

### DIFF
--- a/code-generators/plopfile.mjs
+++ b/code-generators/plopfile.mjs
@@ -17,15 +17,9 @@ export default function (plop) {
 			{
 				type: "append",
 				path: "../src/main.ts",
-				pattern: /@imported-apps-marker/g,
-				template:
-					'import { {{pascalCase name}} } from "./apps/{{name}}";',
-			},
-			{
-				type: "append",
-				path: "../src/main.ts",
 				pattern: /@app-list-marker/g,
-				template: "\tnew {{pascalCase name}}(),",
+				template:
+					'\t{\n\t\tname: "{{sentenceCase name}}",\n\t\tload: () => import("./apps/{{name}}").then((m) => new m.{{pascalCase name}}()),\n\t},',
 			},
 		],
 	});

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -9,6 +9,21 @@ export interface AppContext {
 }
 
 /**
+ * A lazily-loaded app registration. The app's code is only imported when it is
+ * first opened, so each app (and its heavier Three.js addons) is a separate
+ * chunk rather than part of the initial bundle.
+ */
+export interface AppModule {
+	/**
+	 * Display name — drives the selector, the URL hash and the docs slug. Must
+	 * equal the loaded {@link App}'s `name`.
+	 */
+	name: string;
+	/** Import and instantiate the app on demand. */
+	load: () => Promise<App>;
+}
+
+/**
  * Base class every playground app extends. Each app owns its own `scene` and
  * `camera` and implements only the lifecycle hooks it needs. Controls are
  * declared by binding an app's `params` object to a Tweakpane folder inside

--- a/src/core/Playground.ts
+++ b/src/core/Playground.ts
@@ -1,7 +1,7 @@
 import { Clock, SRGBColorSpace, WebGLRenderer } from "three";
 import { Pane } from "tweakpane";
 import type { FolderApi } from "tweakpane";
-import type { App, AppContext } from "./App";
+import type { App, AppContext, AppModule } from "./App";
 
 const REPO_URL = "https://github.com/DanKane2029/three-js-playground";
 
@@ -13,27 +13,34 @@ const slugify = (name: string): string =>
 		.replace(/^-+|-+$/g, "");
 
 /** GitHub link to an app's educational write-up in docs/apps/<slug>/. */
-const docsUrl = (app: App): string =>
-	`${REPO_URL}/blob/main/docs/apps/${slugify(app.name)}/README.md`;
+const docsUrl = (name: string): string =>
+	`${REPO_URL}/blob/main/docs/apps/${slugify(name)}/README.md`;
 
 /**
  * Owns the renderer, the render loop, the Tweakpane panel, resize handling and
- * pointer routing, and switches between the registered apps. The active app is
- * mirrored in the URL hash (e.g. `#ocean`) so it can be linked to directly.
+ * pointer routing, and switches between the registered apps.
+ *
+ * Apps are loaded lazily (via each {@link AppModule}'s `load`), so only the
+ * active app's code is downloaded. Loaded instances are cached and reused. The
+ * active app is mirrored in the URL hash (e.g. `#ocean`) for direct linking.
  */
 export class Playground {
 	private readonly renderer: WebGLRenderer;
 	private readonly pane: Pane;
 	private readonly clock = new Clock();
-	private readonly apps: App[];
+	private readonly apps: AppModule[];
 	private readonly selector: { app: string };
 	private readonly appBinding: { refresh(): void };
+	private readonly instances = new Map<string, App>();
 
-	private current!: App;
+	private current?: App;
 	private appFolder: FolderApi | null = null;
 	private readonly taglineEl: HTMLElement | null;
 
-	constructor(canvas: HTMLCanvasElement, apps: App[]) {
+	/** Increments on every switch so a slow load that lost the race is ignored. */
+	private loadToken = 0;
+
+	constructor(canvas: HTMLCanvasElement, apps: AppModule[]) {
 		if (apps.length === 0)
 			throw new Error("Playground needs at least one app");
 		this.apps = apps;
@@ -59,74 +66,110 @@ export class Playground {
 			})
 			.on("change", (ev) => {
 				const next = this.apps.find((a) => a.name === ev.value);
-				if (next && next !== this.current) this.switchApp(next);
+				if (next && next.name !== this.current?.name)
+					void this.switchApp(next);
 			});
 
 		this.bindEvents(canvas);
-		this.loadApp(initial);
-
-		// Reflect the initial app in the URL without adding a history entry.
-		const slug = slugify(initial.name);
-		if (window.location.hash.replace(/^#/, "") !== slug)
-			window.history.replaceState(null, "", `#${slug}`);
-		window.addEventListener("hashchange", this.onHashChange);
-
-		this.resize();
 		this.renderer.setAnimationLoop(this.frame);
+		void this.boot(initial);
 	}
 
 	private get size(): { width: number; height: number } {
 		return { width: window.innerWidth, height: window.innerHeight };
 	}
 
+	private async boot(initial: AppModule): Promise<void> {
+		await this.switchApp(initial, true);
+		window.addEventListener("hashchange", this.onHashChange);
+		this.resize();
+	}
+
 	/** Find the app whose slug matches a `#slug` hash, if any. */
-	private appForHash(hash: string): App | undefined {
+	private appForHash(hash: string): AppModule | undefined {
 		const slug = hash.replace(/^#/, "");
 		if (!slug) return undefined;
 		return this.apps.find((a) => slugify(a.name) === slug);
 	}
 
-	private loadApp(app: App): void {
+	/** Import (once) and instantiate an app, caching the instance. */
+	private async resolve(entry: AppModule): Promise<App> {
+		let inst = this.instances.get(entry.name);
+		if (!inst) {
+			inst = await entry.load();
+			if (inst.name !== entry.name)
+				console.warn(
+					`App name mismatch: registry "${entry.name}" vs class "${inst.name}"`
+				);
+			this.instances.set(entry.name, inst);
+		}
+		return inst;
+	}
+
+	private async switchApp(entry: AppModule, replaceHash = false): Promise<void> {
+		const token = ++this.loadToken;
+		this.setStatus(`Loading ${entry.name}…`);
+
+		let instance: App;
+		try {
+			instance = await this.resolve(entry);
+		} catch (err) {
+			console.error(`Failed to load app "${entry.name}"`, err);
+			this.setStatus(`Failed to load ${entry.name}`);
+			return;
+		}
+		// A newer switch started while we were importing — drop this result.
+		if (token !== this.loadToken) return;
+
+		this.current?.dispose();
+		this.mount(instance);
+		this.syncSelection(entry, replaceHash);
+	}
+
+	/** Set up an already-instantiated app and (re)build its control folder. */
+	private mount(app: App): void {
 		const { width, height } = this.size;
 		const ctx: AppContext = { renderer: this.renderer, width, height };
-		this.current = app;
 		app.setup(ctx);
 		app.resize(width, height);
+		this.current = app;
 
 		this.appFolder?.dispose();
 		this.appFolder = this.pane.addFolder({ title: app.name });
-
-		// A link to this app's educational docs, above its controls.
 		this.appFolder
 			.addButton({ title: "📖 Read the docs" })
 			.on("click", () =>
-				window.open(docsUrl(app), "_blank", "noopener,noreferrer")
+				window.open(docsUrl(app.name), "_blank", "noopener,noreferrer")
 			);
-
 		app.setupControls(this.appFolder);
 
 		if (this.taglineEl) this.taglineEl.textContent = app.description;
 	}
 
-	private switchApp(next: App): void {
-		this.current.dispose();
-		this.loadApp(next);
-
-		// Keep the dropdown and the URL in sync with the active app.
-		this.selector.app = next.name;
+	/** Keep the dropdown and the URL hash in sync with the active app. */
+	private syncSelection(entry: AppModule, replaceHash: boolean): void {
+		this.selector.app = entry.name;
 		this.appBinding.refresh();
-		const slug = slugify(next.name);
-		if (window.location.hash.replace(/^#/, "") !== slug)
-			window.location.hash = slug;
+		const slug = slugify(entry.name);
+		if (window.location.hash.replace(/^#/, "") !== slug) {
+			if (replaceHash)
+				window.history.replaceState(null, "", `#${slug}`);
+			else window.location.hash = slug;
+		}
+	}
+
+	private setStatus(text: string): void {
+		if (this.taglineEl) this.taglineEl.textContent = text;
 	}
 
 	/** React to back/forward navigation or a manually edited `#slug`. */
 	private onHashChange = (): void => {
 		const next = this.appForHash(window.location.hash);
-		if (next && next !== this.current) this.switchApp(next);
+		if (next && next.name !== this.current?.name) void this.switchApp(next);
 	};
 
 	private frame = (): void => {
+		if (!this.current) return;
 		const dt = this.clock.getDelta();
 		this.current.update(dt, this.clock.elapsedTime);
 		this.current.render(this.renderer);
@@ -135,28 +178,28 @@ export class Playground {
 	private resize = (): void => {
 		const { width, height } = this.size;
 		this.renderer.setSize(width, height);
-		this.current.resize(width, height);
+		this.current?.resize(width, height);
 	};
 
 	private bindEvents(canvas: HTMLCanvasElement): void {
 		window.addEventListener("resize", this.resize);
 
 		canvas.addEventListener("pointerdown", (e) =>
-			this.current.onPointerDown?.(e)
+			this.current?.onPointerDown?.(e)
 		);
 		canvas.addEventListener("pointermove", (e) =>
-			this.current.onPointerMove?.(e)
+			this.current?.onPointerMove?.(e)
 		);
 		canvas.addEventListener("pointerup", (e) =>
-			this.current.onPointerUp?.(e)
+			this.current?.onPointerUp?.(e)
 		);
 		canvas.addEventListener("pointerleave", (e) =>
-			this.current.onPointerLeave?.(e)
+			this.current?.onPointerLeave?.(e)
 		);
 		canvas.addEventListener(
 			"wheel",
 			(e) => {
-				if (this.current.onWheel) {
+				if (this.current?.onWheel) {
 					e.preventDefault();
 					this.current.onWheel(e);
 				}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,36 +1,63 @@
 import "./style.scss";
 
-import type { App } from "./core/App";
+import type { AppModule } from "./core/App";
 import { Playground } from "./core/Playground";
-
-// @imported-apps-marker
-import { GroovyTexture } from "./apps/GroovyTexture";
-import { MandelbrotSet } from "./apps/MandelbrotSet";
-import { TerrainGenerator } from "./apps/terrain_generator/TerrainGenerator";
-import { BloomField } from "./apps/BloomField";
-import { ParticleFlow } from "./apps/ParticleFlow";
-import { PbrViewer } from "./apps/PbrViewer";
-import { Pixelate } from "./apps/Pixelate";
-import { Raymarch } from "./apps/Raymarch";
-import { Mandelbulb } from "./apps/Mandelbulb";
-import { FluidSim } from "./apps/FluidSim";
-import { Ocean } from "./apps/Ocean";
 
 const canvas = document.getElementById("scene") as HTMLCanvasElement;
 
-const apps: App[] = [
+// Apps are registered lazily: each `load` dynamically imports the app so its
+// code (and heavier Three.js addons) only ships when the app is first opened.
+// `name` must match the app class's `name` — it drives the selector, the URL
+// hash and the docs slug.
+const apps: AppModule[] = [
 	// @app-list-marker
-	new GroovyTexture(),
-	new MandelbrotSet(),
-	new TerrainGenerator(),
-	new BloomField(),
-	new ParticleFlow(),
-	new PbrViewer(),
-	new Pixelate(),
-	new Raymarch(),
-	new Mandelbulb(),
-	new FluidSim(),
-	new Ocean(),
+	{
+		name: "Groovy Texture",
+		load: () => import("./apps/GroovyTexture").then((m) => new m.GroovyTexture()),
+	},
+	{
+		name: "Mandelbrot Set",
+		load: () => import("./apps/MandelbrotSet").then((m) => new m.MandelbrotSet()),
+	},
+	{
+		name: "Planet Generator",
+		load: () =>
+			import("./apps/terrain_generator/TerrainGenerator").then(
+				(m) => new m.TerrainGenerator()
+			),
+	},
+	{
+		name: "Bloom Field",
+		load: () => import("./apps/BloomField").then((m) => new m.BloomField()),
+	},
+	{
+		name: "Particle Flow",
+		load: () => import("./apps/ParticleFlow").then((m) => new m.ParticleFlow()),
+	},
+	{
+		name: "PBR Viewer",
+		load: () => import("./apps/PbrViewer").then((m) => new m.PbrViewer()),
+	},
+	{
+		name: "Pixelate",
+		load: () => import("./apps/Pixelate").then((m) => new m.Pixelate()),
+	},
+	{
+		name: "Raymarch SDF",
+		load: () => import("./apps/Raymarch").then((m) => new m.Raymarch()),
+	},
+	{
+		name: "Mandelbulb",
+		load: () => import("./apps/Mandelbulb").then((m) => new m.Mandelbulb()),
+	},
+	{
+		name: "Fluid",
+		load: () => import("./apps/FluidSim").then((m) => new m.FluidSim()),
+	},
+	{
+		name: "Ocean",
+		load: () => import("./apps/Ocean").then((m) => new m.Ocean()),
+	},
 ];
 
 new Playground(canvas, apps);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,18 @@ export default defineConfig({
 		outDir: "dist",
 		target: "es2022",
 		sourcemap: true,
+		// Three.js core is deliberately isolated in its own vendor chunk below;
+		// don't warn about its size.
+		chunkSizeWarningLimit: 700,
+		rollupOptions: {
+			output: {
+				// Keep Three.js core in its own long-lived chunk so shipping
+				// app changes doesn't invalidate it in users' caches.
+				manualChunks(id) {
+					if (id.includes("node_modules/three/")) return "three";
+				},
+			},
+		},
 	},
 	server: {
 		port: 8080,


### PR DESCRIPTION
Implements the "loading split" — apps load on demand instead of all shipping in one bundle.

## What changed
- Apps are registered as lazy `AppModule { name, load }` entries (`main.ts`) instead of eager instances. Each `load` dynamically `import()`s its app, so an app's code **and its heavier Three.js addons** (`EffectComposer`, `OrbitControls`, PMREM/`RoomEnvironment`, `OutputPass`) only download when that app is first opened.
- `Playground` loads apps **asynchronously** with a `Loading …` state, **caches** loaded instances for reuse, and guards against out-of-order loads (a slow import that lost the race is discarded).
- A `manualChunks` rule isolates **Three.js core in its own `three` vendor chunk**, so shipping app changes doesn't invalidate it in users' caches.
- Plop generator updated to emit lazy registry entries (dropped the now-unused import marker).

## Bundle impact
| | before | after |
|---|--:|--:|
| initial JS (index) | 692 kB | **156 kB** |
| Three.js core | (in index) | 576 kB, **separate cacheable chunk** |
| each app | (all in index) | **own on-demand chunk** (2–14 kB) |

Adding future apps no longer grows the initial download.

## Verified (headless WebGL)
- `#ocean` deep-link loads + renders (tagline set post-load), docs button present
- Switching to **Bloom Field** lazily loads its post-processing pipeline and renders, hash → `#bloom-field`
- 0 page/console errors; `tsc`/`eslint`/`vite build` all clean (build warning resolved)

Builds on the hash-routing/docs work merged in #5.