### PR TITLE
UI polish: clickable README, WebGL fallback, keyboard shortcuts, FPS/quality panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ the top-right corner and tweak its parameters live.
 
 **▶ Live demo: <https://dankane2029.github.io/three-js-playground/>**
 
+Keyboard shortcuts: **←/→** switch apps · **f** fullscreen · **h** hide the UI
+for a clean view. The **Performance** panel shows a live FPS graph and a
+resolution control (lower it to trade sharpness for speed).
+
 **Stack:** Three.js · TypeScript · [Vite](https://vite.dev/) ·
 [Tweakpane](https://tweakpane.github.io/docs/) · ESLint 9 · Prettier 3.
 
@@ -52,7 +56,7 @@ Each app has an educational deep-dive — the concepts and math behind it — in
 
 ### Groovy Texture
 
-![Groovy Texture](docs/screenshots/groovy-texture.png)
+[![Groovy Texture](docs/screenshots/groovy-texture.png)](https://dankane2029.github.io/three-js-playground/#groovy-texture)
 
 A vibrant 1970s-inspired five-pointed star. A fragment shader uses a signed
 distance function to draw color bands moving inward. The five colors, wave speed,
@@ -60,7 +64,7 @@ and star size are all adjustable.
 
 ### Mandelbrot Set
 
-![Mandelbrot Set](docs/screenshots/mandelbrot-set.png)
+[![Mandelbrot Set](docs/screenshots/mandelbrot-set.png)](https://dankane2029.github.io/three-js-playground/#mandelbrot-set)
 
 The famous fractal, computed in a fragment shader by iterating
 $Z_{n+1}=Z_n^2+C$ and coloring each pixel by how quickly the sequence escapes.
@@ -69,7 +73,7 @@ adjustable.
 
 ### Planet Generator
 
-![Planet Generator](docs/screenshots/planet-generator.png)
+[![Planet Generator](docs/screenshots/planet-generator.png)](https://dankane2029.github.io/three-js-playground/#planet-generator)
 
 A procedural mini planet. Seamless 3D simplex-noise FBM (sampled on the sphere,
 so there's no UV seam or pole pinching) displaces the surface in the vertex
@@ -84,14 +88,14 @@ level, amplitude, frequency, octaves, atmosphere, clouds, and biome colors.
 
 ### Bloom Field
 
-![Bloom Field](docs/screenshots/bloom-field.png)
+[![Bloom Field](docs/screenshots/bloom-field.png)](https://dankane2029.github.io/three-js-playground/#bloom-field)
 
 A ring of emissive shapes rendered through an `EffectComposer` pipeline with an
 `UnrealBloomPass`. Adjust the bloom strength, radius, and threshold.
 
 ### Particle Flow
 
-![Particle Flow](docs/screenshots/particle-flow.png)
+[![Particle Flow](docs/screenshots/particle-flow.png)](https://dankane2029.github.io/three-js-playground/#particle-flow)
 
 A GPU-driven particle field: every particle's animated position is computed in
 the vertex shader from its seed and time, plus a repulsion from the pointer. Move
@@ -100,7 +104,7 @@ strength, and color.
 
 ### PBR Viewer
 
-![PBR Viewer](docs/screenshots/pbr-viewer.png)
+[![PBR Viewer](docs/screenshots/pbr-viewer.png)](https://dankane2029.github.io/three-js-playground/#pbr-viewer)
 
 A physically based scene lit by image-based lighting (`RoomEnvironment` via
 `PMREMGenerator`) with orbit controls. Adjust metalness, roughness, environment
@@ -108,14 +112,14 @@ intensity, and auto-rotation.
 
 ### Pixelate
 
-![Pixelate](docs/screenshots/pixelate.png)
+[![Pixelate](docs/screenshots/pixelate.png)](https://dankane2029.github.io/three-js-playground/#pixelate)
 
 A spinning shape run through a custom pixelate post-process shader (a `ShaderPass`
 that snaps output pixels to a grid). Adjust the pixel size.
 
 ### Raymarch SDF
 
-![Raymarch SDF](docs/screenshots/raymarch-sdf.png)
+[![Raymarch SDF](docs/screenshots/raymarch-sdf.png)](https://dankane2029.github.io/three-js-playground/#raymarch-sdf)
 
 A fullscreen raymarched signed-distance-field scene: three animated primitives
 fused with a smooth minimum, on a checkered floor with soft shadows, ambient
@@ -124,7 +128,7 @@ optional infinite domain repetition, fog, and the two-color palette.
 
 ### Mandelbulb
 
-![Mandelbulb](docs/screenshots/mandelbulb.png)
+[![Mandelbulb](docs/screenshots/mandelbulb.png)](https://dankane2029.github.io/three-js-playground/#mandelbulb)
 
 A fullscreen raymarched Mandelbulb — the 3D analogue of the Mandelbrot set —
 using the classic distance estimator with orbit-trap coloring and a glow halo.
@@ -133,7 +137,7 @@ iteration count, glow, and colors.
 
 ### Fluid
 
-![Fluid](docs/screenshots/fluid.png)
+[![Fluid](docs/screenshots/fluid.png)](https://dankane2029.github.io/three-js-playground/#fluid)
 
 A real-time GPU fluid simulation: a grid-based Navier–Stokes solver (Jos Stam's
 "stable fluids") that ping-pongs velocity, dye, and pressure through
@@ -143,7 +147,7 @@ Adjust curl, dissipation, pressure iterations, and splat radius.
 
 ### Ocean
 
-![Ocean](docs/screenshots/ocean.png)
+[![Ocean](docs/screenshots/ocean.png)](https://dankane2029.github.io/three-js-playground/#ocean)
 
 A 3D ocean of Gerstner (trochoidal) waves displaced in the vertex shader, with
 analytic normals, a Fresnel blend between deep water and a reflected procedural

--- a/src/core/Playground.ts
+++ b/src/core/Playground.ts
@@ -32,6 +32,10 @@ export class Playground {
 	private readonly selector: { app: string };
 	private readonly appBinding: { refresh(): void };
 	private readonly instances = new Map<string, App>();
+	private readonly perf = {
+		fps: 0,
+		quality: Math.min(window.devicePixelRatio, 2),
+	};
 
 	private current?: App;
 	private appFolder: FolderApi | null = null;
@@ -69,6 +73,28 @@ export class Playground {
 				if (next && next.name !== this.current?.name)
 					void this.switchApp(next);
 			});
+
+		// Performance panel: a live FPS graph and a render-resolution control
+		// (lower it to trade sharpness for speed on weaker GPUs).
+		const perfFolder = this.pane.addFolder({
+			title: "Performance",
+			expanded: false,
+		});
+		perfFolder.addBinding(this.perf, "fps", {
+			readonly: true,
+			view: "graph",
+			min: 0,
+			max: 120,
+			interval: 100,
+		});
+		perfFolder
+			.addBinding(this.perf, "quality", {
+				label: "resolution",
+				min: 0.5,
+				max: 2,
+				step: 0.25,
+			})
+			.on("change", (ev) => this.setQuality(ev.value));
 
 		this.bindEvents(canvas);
 		this.renderer.setAnimationLoop(this.frame);
@@ -126,6 +152,17 @@ export class Playground {
 		this.syncSelection(entry, replaceHash);
 	}
 
+	/** Switch to the previous/next app in the list, wrapping around. */
+	cycle(delta: number): void {
+		const cur = this.current;
+		if (!cur) return;
+		const i = this.apps.findIndex((a) => a.name === cur.name);
+		if (i < 0) return;
+		const next =
+			this.apps[(i + delta + this.apps.length) % this.apps.length];
+		if (next.name !== cur.name) void this.switchApp(next);
+	}
+
 	/** Set up an already-instantiated app and (re)build its control folder. */
 	private mount(app: App): void {
 		const { width, height } = this.size;
@@ -135,7 +172,8 @@ export class Playground {
 		this.current = app;
 
 		this.appFolder?.dispose();
-		this.appFolder = this.pane.addFolder({ title: app.name });
+		// index 1 keeps the app folder above the Performance folder on switch.
+		this.appFolder = this.pane.addFolder({ title: app.name, index: 1 });
 		this.appFolder
 			.addButton({ title: "📖 Read the docs" })
 			.on("click", () =>
@@ -171,9 +209,17 @@ export class Playground {
 	private frame = (): void => {
 		if (!this.current) return;
 		const dt = this.clock.getDelta();
+		// Smoothed FPS for the Performance panel (the monitor polls perf.fps).
+		if (dt > 0) this.perf.fps += (1 / dt - this.perf.fps) * 0.1;
 		this.current.update(dt, this.clock.elapsedTime);
 		this.current.render(this.renderer);
 	};
+
+	/** Change the device-pixel-ratio the renderer draws at (quality vs. speed). */
+	private setQuality(ratio: number): void {
+		this.renderer.setPixelRatio(ratio);
+		this.resize();
+	}
 
 	private resize = (): void => {
 		const { width, height } = this.size;

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,14 +60,104 @@ const apps: AppModule[] = [
 	},
 ];
 
-new Playground(canvas, apps);
-
-// Fullscreen toggle.
-const fullscreenButton = document.getElementById("fullscreen-toggle");
-fullscreenButton?.addEventListener("click", () => {
-	if (document.fullscreenElement) {
-		void document.exitFullscreen();
-	} else {
-		void document.documentElement.requestFullscreen();
+/** Does this browser have a usable WebGL context at all? */
+function webglAvailable(): boolean {
+	try {
+		const test = document.createElement("canvas");
+		return !!(
+			window.WebGLRenderingContext &&
+			(test.getContext("webgl2") || test.getContext("webgl"))
+		);
+	} catch {
+		return false;
 	}
-});
+}
+
+/** Cover the page with a friendly message (used when WebGL is unavailable). */
+function showFatal(message: string): void {
+	const el = document.createElement("div");
+	el.setAttribute("role", "alert");
+	el.textContent = message;
+	Object.assign(el.style, {
+		position: "fixed",
+		inset: "0",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		textAlign: "center",
+		padding: "2rem",
+		font: "500 1.05rem/1.6 system-ui, -apple-system, sans-serif",
+		color: "#e8e8ef",
+		background: "#0a0a12",
+		zIndex: "20",
+	});
+	document.body.appendChild(el);
+}
+
+function toggleFullscreen(): void {
+	if (document.fullscreenElement) void document.exitFullscreen();
+	else void document.documentElement.requestFullscreen();
+}
+
+/** Wire up the fullscreen button and keyboard shortcuts around a Playground. */
+function setupChrome(playground: Playground): void {
+	document
+		.getElementById("fullscreen-toggle")
+		?.addEventListener("click", toggleFullscreen);
+
+	// Elements toggled by the "hide UI" shortcut (kept in the DOM so they can
+	// still receive events; only their visibility changes).
+	const chrome = ["app-header", "ui", "fullscreen-toggle"]
+		.map((id) => document.getElementById(id))
+		.filter((el): el is HTMLElement => el !== null);
+	let uiHidden = false;
+	const toggleUI = (): void => {
+		uiHidden = !uiHidden;
+		for (const el of chrome) el.style.visibility = uiHidden ? "hidden" : "";
+	};
+
+	window.addEventListener("keydown", (e) => {
+		// Don't hijack keys while typing in a control (Tweakpane inputs, etc.).
+		const active = document.activeElement as HTMLElement | null;
+		if (
+			active &&
+			(active.isContentEditable ||
+				["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName))
+		)
+			return;
+		if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+		switch (e.key) {
+			case "f":
+				toggleFullscreen();
+				break;
+			case "h":
+				toggleUI();
+				break;
+			case "ArrowRight":
+				playground.cycle(1);
+				break;
+			case "ArrowLeft":
+				playground.cycle(-1);
+				break;
+			default:
+				return;
+		}
+		e.preventDefault();
+	});
+}
+
+if (!webglAvailable()) {
+	showFatal(
+		"This playground needs WebGL, which your browser doesn't appear to " +
+			"support or has disabled. Try a recent Chrome, Firefox, Edge or " +
+			"Safari with hardware acceleration enabled."
+	);
+} else {
+	try {
+		setupChrome(new Playground(canvas, apps));
+	} catch (err) {
+		console.error("Failed to start the playground:", err);
+		showFatal("Something went wrong initialising WebGL on this device.");
+	}
+}


### PR DESCRIPTION
Four quick, low-risk improvements in one PR.

## Clickable README gallery
Each screenshot in the README now links to its **live deep-linked app** (`…/#slug`), turning the gallery into a launcher — leverages the URL-hash routing.

## Graceful WebGL fallback
Detects missing/disabled WebGL up front (and guards `Playground` init in a try/catch); shows a friendly full-page message instead of a blank black canvas.

## Keyboard shortcuts
- **←/→** — previous/next app (wraps)
- **f** — toggle fullscreen
- **h** — hide/show the UI for a clean view

Ignored while a control is focused (Tweakpane inputs, the app `<select>`, etc.), and skipped when a modifier key is held.

## Performance panel (FPS + quality)
A new **Performance** folder with:
- a live **smoothed-FPS graph** (Tweakpane monitor, polled every 100 ms), and
- a **resolution** slider (device pixel ratio 0.5–2) to trade sharpness for speed on weaker GPUs.

The app's control folder is pinned above it so panel order stays stable across app switches.

## Verified (headless WebGL)
- Deep-link + gallery links resolve to the right `#slug`
- Performance folder + FPS graph build without error; resolution control present
- `←/→` cycle apps (hash updates), `h` toggles `#ui` visibility
- 0 page/console errors; `tsc`/`eslint`/`vite build` all clean