### PR TITLE
Add CI workflow to validate pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+# Validate every pull request before it can be merged.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer push to the same PR cancels an in-progress run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, type-check & build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      # `build` runs `tsc --noEmit` (type-check) followed by `vite build`.
+      - name: Type-check & build
+        run: npm run build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` so every PR is validated before merge.

On `pull_request` (and manual `workflow_dispatch`) it runs:
- **Lint** — `npm run lint` (eslint)
- **Type-check & build** — `npm run build` (`tsc --noEmit` then `vite build`)

Uses the same Node 20 + `npm ci` setup as the deploy workflow, and cancels superseded runs on the same PR. Type errors, lint failures, or broken builds now fail the check before they can reach `main`.

Verified both steps pass locally. This PR is its own first run of the workflow.